### PR TITLE
ONLY deploy to gke cluster

### DIFF
--- a/bin/pymgke
+++ b/bin/pymgke
@@ -446,30 +446,3 @@ if [ -z "$ROLLBACK" ]; then
 else
     echo "ROLLBACK: not waiting for staging to be ready"
 fi
-
-# ------------------------------------------------------------------------------
-#
-# RUN ACCEPTANCE TESTS
-#
-# ------------------------------------------------------------------------------
-
-cd $ROOTDIR
-if [ ! -z "$DO_TEST" ]; then
-    if [ -z "$ROLLBACK" ]; then
-        echo ""
-        echo "=> Executing tests against $IP:$TEST_PORT"
-        TEST_PORT=$(pymconfig --port)
-        pymtest --host $IP --port $TEST_PORT --no-ssl-check
-
-        RC=$?
-        if [ "$RC" -ne 0 ]; then
-            echo "ERROR: Acceptance tests failed against $IP - deploy aborted"
-            exit 1
-        fi
-
-    else
-        echo "ROLLBACK: skip staging tests"
-    fi
-fi
-
-echo "=> Done."


### PR DESCRIPTION
In [pymgke line 461]( https://github.com/pymacaron/pymacaron-gcp/blob/master/bin/pymgke#L461)
Should it instead be:
`
TEST_PORT=$(pymconfig $PYMCONFIG_ARGS --port)
`
Like everywhere else in the file?

If you dont add the `$PYMCONFIG_ARGS` then it tries to look for pym-config.yml which is not something we want right?
When we deploy we deploy we specify and enviroment to deploy to: live or staging so we want it to look for pym-config.<staging/live>.yml

My deployment breaks because of this, since I am running it with tests and it tries to look for a non existent pym-config.yml (no repo has one)

Actually since pymdeploy already does testing after deploying ([pymdeploy](https://github.com/pymacaron/pymacaron/blob/master/bin/pymdeploy#L234)) , I think it is better if we remove the testing from pymgke since it is a one-purpose tool: deploy to a gke cluster and therefore we dont "waste" time testing 2 times same code in same enviroment