### PR TITLE
Fix/only test if one env

### DIFF
--- a/bin/pymgke
+++ b/bin/pymgke
@@ -446,3 +446,30 @@ if [ -z "$ROLLBACK" ]; then
 else
     echo "ROLLBACK: not waiting for staging to be ready"
 fi
+
+# ------------------------------------------------------------------------------
+#
+# RUN ACCEPTANCE TESTS (if only one env avaliable for deploy)
+#
+# ------------------------------------------------------------------------------
+
+cd $ROOTDIR
+if [ ! -z "$DO_TEST" ] && [ -f "pym-config.yaml" ]; then
+    if [ -z "$ROLLBACK" ]; then
+        echo ""
+        echo "=> Executing tests against $IP:$TEST_PORT"
+        TEST_PORT=$(pymconfig --port)
+        pymtest --host $IP --port $TEST_PORT --no-ssl-check
+
+        RC=$?
+        if [ "$RC" -ne 0 ]; then
+            echo "ERROR: Acceptance tests failed against $IP - deploy aborted"
+            exit 1
+        fi
+
+    else
+        echo "ROLLBACK: skip staging tests"
+    fi
+fi
+
+echo "=> Done."

--- a/bin/pymgke
+++ b/bin/pymgke
@@ -446,30 +446,3 @@ if [ -z "$ROLLBACK" ]; then
 else
     echo "ROLLBACK: not waiting for staging to be ready"
 fi
-
-# ------------------------------------------------------------------------------
-#
-# RUN ACCEPTANCE TESTS
-#
-# ------------------------------------------------------------------------------
-
-cd $ROOTDIR
-if [ ! -z "$DO_TEST" ]; then
-    if [ -z "$ROLLBACK" ]; then
-        echo ""
-        echo "=> Executing tests against $IP:$TEST_PORT"
-        TEST_PORT=$(pymconfig --port)
-        pymtest --host $IP --port $TEST_PORT --no-ssl-check
-
-        RC=$?
-        if [ "$RC" -ne 0 ]; then
-            echo "ERROR: Acceptance tests failed against $IP - deploy aborted"
-            exit 1
-        fi
-
-    else
-        echo "ROLLBACK: skip staging tests"
-    fi
-fi
-
-echo "=> Done."


### PR DESCRIPTION
To allow projects that only have one possible target enviroment to test their enviroment without needing to use `pymdeploy`, we check if the pym-config.yaml exists, else we skip tests since they will be ran later by `pymdpeloy`